### PR TITLE
fix(utilities): allows border radius object to rectangles

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -70,7 +70,7 @@ export const defaultSvgPath = ({
   borderRadius: number
   borderRadiusObject?: BorderRadiusObject
 }): SvgPath => {
-  if (radius) {
+  if (radius || borderRadiusObject) {
     const borderRadiusTopRight = getBorderRadiusOrDefault(
       borderRadiusObject?.topRight,
       radius,


### PR DESCRIPTION
This allows the `borderRadiusObject` prop to be used in any rectangle, without having to pass a `borderRadius={1}` prop to "hack" the `if` condition and allow rounding.