### PR TITLE
fix(svg-mask): consider devices with on-screen buttons

### DIFF
--- a/src/components/SvgMask.tsx
+++ b/src/components/SvgMask.tsx
@@ -14,7 +14,7 @@ import { IStep, ValueXY } from '../types'
 import { svgMaskPathMorph } from '../utilities'
 import { AnimatedSvgPath } from './AnimatedPath'
 
-const windowDimensions = Dimensions.get('window')
+const screenDimensions = Dimensions.get('screen')
 
 interface Props {
   size: ValueXY
@@ -37,10 +37,10 @@ interface State {
   previousPath: string
 }
 
-const FIRST_PATH = `M0,0H${windowDimensions.width}V${
-  windowDimensions.height
-}H0V0ZM${windowDimensions.width / 2},${
-  windowDimensions.height / 2
+const FIRST_PATH = `M0,0H${screenDimensions.width}V${
+  screenDimensions.height
+}H0V0ZM${screenDimensions.width / 2},${
+  screenDimensions.height / 2
 } h 1 v 1 h -1 Z`
 
 const IS_WEB = Platform.OS !== 'web'
@@ -62,8 +62,8 @@ export class SvgMask extends Component<Props, State> {
 
     this.state = {
       canvasSize: {
-        x: windowDimensions.width,
-        y: windowDimensions.height,
+        x: screenDimensions.width,
+        y: screenDimensions.height,
       },
       size: props.size,
       position: props.position,


### PR DESCRIPTION
Replaces the use of the window size with the screen size, to ensure that on Android devices (that the gesture option is enabled, that is, that it does not use buttons on the screen) the mask is correctly sized.

As it is today, on Android devices that disable the on-screen buttons on:
![PHOTO-2020-09-30-17-23-55](https://user-images.githubusercontent.com/8412815/94735954-e3878880-0341-11eb-8f51-1de344374f79.jpg)
