### PR TITLE
fix(provider): unregisterStep and reset canStart value

### DIFF
--- a/src/components/TourGuideProvider.tsx
+++ b/src/components/TourGuideProvider.tsx
@@ -71,10 +71,14 @@ export const TourGuideProvider = ({
   }, [visible, currentStep])
 
   useEffect(() => {
-    if (mounted && Object.entries(steps).length > 0) {
-      setCanStart(true)
-      if (startAtMount) {
-        start()
+    if (mounted) {
+      if (Object.entries(steps).length > 0) {
+        setCanStart(true)
+        if (startAtMount) {
+          start()
+        }
+      } else {
+        setCanStart(false)
       }
     }
   }, [mounted, steps])

--- a/src/components/TourGuideProvider.tsx
+++ b/src/components/TourGuideProvider.tsx
@@ -141,11 +141,11 @@ export const TourGuideProvider = ({
     if (!mounted) {
       return
     }
-    setSteps(
-      Object.entries(steps as StepObject)
+    setSteps((previousSteps) => {
+      return Object.entries(previousSteps as StepObject)
         .filter(([key]) => key !== stepName)
-        .reduce((obj, [key, val]) => Object.assign(obj, { [key]: val }), {}),
-    )
+        .reduce((obj, [key, val]) => Object.assign(obj, { [key]: val }), {})
+    })
   }
 
   const getCurrentStep = () => currentStep


### PR DESCRIPTION
- fix `unregisterStep` logic in `TourGuideProvider` to prevent race condition when unmounting many steps simultaneously that could cause `unregisterStep` fails.

- set `canStart` value to be `false` when there are no steps mounted/registered.

**NOTE :** this PR also made to fix issue #17 , allowing us to put `<TourGuideZone/>`  in BottomTab of React Navigation and only show it when we want to show them (based on `isTourGuide` value in `<TourGuideZone/>` ).