### PR TITLE
fix(tourGuideZoneByPosition): adding optional params text and its styling

### DIFF
--- a/src/components/TourGuideZoneByPosition.tsx
+++ b/src/components/TourGuideZoneByPosition.tsx
@@ -56,6 +56,7 @@ export const TourGuideZoneByPosition = ({
           text,
         }}
         style={{
+          position: 'absolute',
           height,
           width,
           top,

--- a/src/components/TourGuideZoneByPosition.tsx
+++ b/src/components/TourGuideZoneByPosition.tsx
@@ -17,6 +17,7 @@ interface TourGuideZoneByPositionProps {
   containerStyle?: StyleProp<ViewStyle>
   keepTooltipPosition?: boolean
   tooltipBottomOffset?: number
+  text?: string
 }
 
 export const TourGuideZoneByPosition = ({
@@ -33,6 +34,7 @@ export const TourGuideZoneByPosition = ({
   keepTooltipPosition,
   tooltipBottomOffset,
   borderRadiusObject,
+  text,
 }: TourGuideZoneByPositionProps) => {
   if (!isTourGuide) {
     return null
@@ -51,6 +53,7 @@ export const TourGuideZoneByPosition = ({
           keepTooltipPosition,
           tooltipBottomOffset,
           borderRadiusObject,
+          text,
         }}
         style={{
           height,


### PR DESCRIPTION
## Changelog
- adding optional params `text` for `TourGuideZoneByPosition`
- add style `{position: 'absolute')` in `TourGuideZoneByPosition`'s style to be able to place tooltip from position `bottom`.