### PR TITLE
fix(TourGuideProvider): fix fractional pixels (only for Retina display)

### DIFF
--- a/src/components/TourGuideProvider.tsx
+++ b/src/components/TourGuideProvider.tsx
@@ -89,8 +89,8 @@ export const TourGuideProvider = ({
     await modal.current?.animateMove({
       width: size.width + OFFSET_WIDTH,
       height: size.height + OFFSET_WIDTH,
-      left: size.x - OFFSET_WIDTH / 2,
-      top: size.y - OFFSET_WIDTH / 2 + (verticalOffset || 0),
+      left: Math.round(size.x) - OFFSET_WIDTH / 2,
+      top: Math.round(size.y) - OFFSET_WIDTH / 2 + (verticalOffset || 0),
     })
   }
 


### PR DESCRIPTION
it seems the problem here is in float pixel values. In reality, there is no fractional pixel, and therefore when we try to select a fractional pixel, inaccuracies can occur. This causes image misalignment on the web. I suggest rounding the 'top' and 'left' values to fix plotting inaccuracies.

**This bug only appears on Retina displays**

## Before:
![image](https://user-images.githubusercontent.com/25533519/99384744-ee41b100-28e0-11eb-847a-be6440fc888e.png)
![image](https://user-images.githubusercontent.com/25533519/99384783-fb5ea000-28e0-11eb-855a-1c6e97e15760.png)


## After:
![image](https://user-images.githubusercontent.com/25533519/99384626-c2263000-28e0-11eb-8b2b-0b58f665b50f.png)
![image](https://user-images.githubusercontent.com/25533519/99384680-d5d19680-28e0-11eb-9421-cf5d7563d1c0.png)
