### PR TITLE
Guard against potential bad measure calls

### DIFF
--- a/src/components/TourGuideProvider.tsx
+++ b/src/components/TourGuideProvider.tsx
@@ -85,7 +85,9 @@ export const TourGuideProvider = ({
 
   const moveToCurrentStep = async () => {
     const size = await currentStep!.target.measure()
-
+    if (isNaN(size.width) || isNaN(size.height) || isNaN(size.x) || isNaN(size.y)) {
+      return;
+    }
     await modal.current?.animateMove({
       width: size.width + OFFSET_WIDTH,
       height: size.height + OFFSET_WIDTH,


### PR DESCRIPTION
There are scenarios where navigating too quickly would cause measure calls to go bad, giving NaN measurements. As a result, this would cause a `malformed JS calls` error from trying to send NaN values through the bridge.