### PR TITLE
Fix Step measures when there's a borderRadius set

### DIFF
--- a/src/components/ConnectedStep.tsx
+++ b/src/components/ConnectedStep.tsx
@@ -84,6 +84,7 @@ export class ConnectedStep extends React.Component<Props> {
       const measure = () => {
         // Wait until the wrapper element appears
         if (this.wrapper && this.wrapper.measure) {
+          const {borderRadius} = this.props;
           this.wrapper.measure(
             (
               _ox: number,
@@ -94,9 +95,9 @@ export class ConnectedStep extends React.Component<Props> {
               y: number,
             ) =>
               resolve({
-                x,
+                x: borderRadius ? x + borderRadius : x,
                 y,
-                width,
+                width: borderRadius ? width - borderRadius * 2 : width,
                 height,
               }),
             reject,


### PR DESCRIPTION
When measuring the size and position of a step with a borderRadius set there was a miscalculation on the width and the x position. This PR compensates those miscalculations and ensures the mask is applied on the proper spot and size.

Example:

```
          <TourGuideZone zone={1} text={'A react-native-copilot remastered! 🎉'} borderRadius={18}>
              <ActionButton {...props} />
          </TourGuideZone>
```

**This code resulted in:**

![Screenshot 2021-03-23 at 13 32 56](https://user-images.githubusercontent.com/807710/112147210-b7581080-8bdc-11eb-9969-fc43686f4b59.png)

**After this PR, the code results in:**

![Screenshot 2021-03-23 at 13 32 22](https://user-images.githubusercontent.com/807710/112147173-ae673f00-8bdc-11eb-97da-b4c93c59e670.png)

