### PR TITLE
Block interaction with outside area

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ export interface TourGuideProviderProps {
   animationDuration?: number
   children: React.ReactNode
   dismissOnPress?: boolean
+  preventOutsideInteraction?:boolean
 }
 
 interface TooltipProps {
@@ -318,6 +319,19 @@ List of available events is:
 - `start` — Copilot tutorial has started.
 - `stop` — Copilot tutorial has ended or skipped.
 - `stepChange` — Next step is triggered. Passes [`Step`](https://github.com/mohebifar/react-native-copilot/blob/master/src/types.js#L2) instance as event handler argument.
+
+
+### Prevent Outside Interaction
+
+Sometimes you need to prevent users to interact with app while tour is shown, in such case `preventOutsideInteraction` prop is up for you.
+
+```default: false```
+
+```jsx
+<TourGuideProvider preventOutsideInteraction>
+  <AppContent />
+</TourGuideProvider>
+```
 
 ## Contributing
 

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -33,9 +33,14 @@ export interface ModalProps {
   backdropColor: string
   labels: Labels
   dismissOnPress?: boolean
+  preventOutsideInteraction?: boolean
+
   easing(value: number): number
+
   stop(): void
+
   next(): void
+
   prev(): void
 }
 
@@ -74,6 +79,7 @@ export class Modal extends React.Component<ModalProps, State> {
     backdropColor: 'rgba(0, 0, 0, 0.4)',
     labels: {},
     isHorizontal: false,
+    preventOutsideInteraction: false,
   }
 
   layout?: Layout = {
@@ -189,9 +195,9 @@ export class Modal extends React.Component<ModalProps, State> {
       verticalPosition === 'bottom'
         ? tooltip.top
         : obj.top -
-          MARGIN -
-          135 -
-          (this.props.currentStep!.tooltipBottomOffset || 0)
+        MARGIN -
+        135 -
+        (this.props.currentStep!.tooltipBottomOffset || 0)
     const translateAnim = Animated.timing(this.state.tooltipTranslateY, {
       toValue,
       duration,
@@ -290,6 +296,7 @@ export class Modal extends React.Component<ModalProps, State> {
           styles.tooltip,
           this.props.tooltipStyle,
           {
+            zIndex: 99,
             opacity,
             transform: [{ translateY: this.state.tooltipTranslateY }],
           },
@@ -308,6 +315,12 @@ export class Modal extends React.Component<ModalProps, State> {
     )
   }
 
+  renderNonInteractionPlaceholder() {
+    return this.props.preventOutsideInteraction ? <View
+      style={[StyleSheet.absoluteFill, styles.nonInteractionPlaceholder]} /> : null
+  }
+
+
   render() {
     const containerVisible = this.state.containerVisible || this.props.visible
     const contentVisible = this.state.layout && containerVisible
@@ -324,9 +337,12 @@ export class Modal extends React.Component<ModalProps, State> {
           onLayout={this.handleLayoutChange}
           pointerEvents='box-none'
         >
+
+
           {contentVisible && (
             <>
               {this.renderMask()}
+              {this.renderNonInteractionPlaceholder()}
               {this.renderTooltip()}
             </>
           )}

--- a/src/components/TourGuideProvider.tsx
+++ b/src/components/TourGuideProvider.tsx
@@ -31,6 +31,7 @@ export interface TourGuideProviderProps {
   animationDuration?: number
   children: React.ReactNode
   dismissOnPress?: boolean
+  preventOutsideInteraction?: boolean
 }
 
 export const TourGuideProvider = ({
@@ -47,6 +48,7 @@ export const TourGuideProvider = ({
   verticalOffset,
   startAtMount = false,
   dismissOnPress = false,
+  preventOutsideInteraction = false,
 }: TourGuideProviderProps) => {
   const [visible, setVisible] = useState<boolean | undefined>(undefined)
   const [currentStep, updateCurrentStep] = useState<IStep | undefined>()
@@ -213,6 +215,7 @@ export const TourGuideProvider = ({
             maskOffset,
             borderRadius,
             dismissOnPress,
+            preventOutsideInteraction,
           }}
         />
       </TourGuideContext.Provider>

--- a/src/components/style.ts
+++ b/src/components/style.ts
@@ -13,6 +13,7 @@ export interface IStyle {
   buttonText: TextStyle
   bottomBar: ViewStyle
   overlayContainer: ViewStyle
+  nonInteractionPlaceholder: ViewStyle
 }
 
 export default StyleSheet.create<IStyle>({
@@ -34,6 +35,11 @@ export default StyleSheet.create<IStyle>({
     alignItems: 'center',
     justifyContent: 'center',
     paddingBottom: 16,
+    zIndex: Z_INDEX - 1,
+  },
+  nonInteractionPlaceholder: {
+    backgroundColor: 'transparent',
+    zIndex: Z_INDEX - 2,
   },
   tooltipText: {
     textAlign: 'center',


### PR DESCRIPTION
This PR extends the current API with new property`preventOutsideInteraction` it allows preventing users to interact with the app while the tour is shown.

resolves #23  resolves #3 