### PR TITLE
fix: change tooltip content when the opacity is 0

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -107,6 +107,7 @@ export class Modal extends React.Component<ModalProps, State> {
 
   handleLayoutChange = ({ nativeEvent: { layout } }: LayoutChangeEvent) => {
     this.layout = layout
+    console.log("test");
   }
 
   measure(): Promise<Layout> {

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -48,6 +48,8 @@ interface Layout {
 }
 
 interface State {
+  isFirstStep: boolean
+  isLastStep: boolean
   tooltip: object
   notAnimated?: boolean
   containerVisible: boolean
@@ -56,7 +58,7 @@ interface State {
   position?: ValueXY
   tooltipTranslateY: Animated.Value
   opacity: Animated.Value
-  currentStep?: IStep;
+  currentStep?: IStep
 }
 
 interface Move {
@@ -87,6 +89,8 @@ export class Modal extends React.Component<ModalProps, State> {
   }
 
   state = {
+    isFirstStep: false,
+    isLastStep: false,
     tooltip: {},
     containerVisible: false,
     tooltipTranslateY: new Animated.Value(400),
@@ -212,7 +216,11 @@ export class Modal extends React.Component<ModalProps, State> {
     })
     this.state.opacity.setValue(0)
     // Set the tooltip content when the opacity is 0
-    this.setState({currentStep: this.props.currentStep});
+    this.setState({
+      isFirstStep: this.props.isFirstStep,
+      isLastStep: this.props.isLastStep,
+      currentStep: this.props.currentStep,
+    })
     if (
       // @ts-ignore
       toValue !== this.state.tooltipTranslateY._value &&
@@ -304,8 +312,8 @@ export class Modal extends React.Component<ModalProps, State> {
         ]}
       >
         <TooltipComponent
-          isFirstStep={this.props.isFirstStep}
-          isLastStep={this.props.isLastStep}
+          isFirstStep={this.state.isFirstStep}
+          isLastStep={this.state.isLastStep}
           currentStep={this.state.currentStep!}
           handleNext={this.handleNext}
           handlePrev={this.handlePrev}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -56,6 +56,7 @@ interface State {
   position?: ValueXY
   tooltipTranslateY: Animated.Value
   opacity: Animated.Value
+  currentStep?: IStep;
 }
 
 interface Move {
@@ -93,6 +94,7 @@ export class Modal extends React.Component<ModalProps, State> {
     layout: undefined,
     size: undefined,
     position: undefined,
+    currentStep: undefined,
   }
 
   constructor(props: ModalProps) {
@@ -107,7 +109,6 @@ export class Modal extends React.Component<ModalProps, State> {
 
   handleLayoutChange = ({ nativeEvent: { layout } }: LayoutChangeEvent) => {
     this.layout = layout
-    console.log("test");
   }
 
   measure(): Promise<Layout> {
@@ -210,6 +211,8 @@ export class Modal extends React.Component<ModalProps, State> {
       useNativeDriver: true,
     })
     this.state.opacity.setValue(0)
+    // Set the tooltip content when the opacity is 0
+    this.setState({currentStep: this.props.currentStep});
     if (
       // @ts-ignore
       toValue !== this.state.tooltipTranslateY._value &&
@@ -303,7 +306,7 @@ export class Modal extends React.Component<ModalProps, State> {
         <TooltipComponent
           isFirstStep={this.props.isFirstStep}
           isLastStep={this.props.isLastStep}
-          currentStep={this.props.currentStep!}
+          currentStep={this.state.currentStep!}
           handleNext={this.handleNext}
           handlePrev={this.handlePrev}
           handleStop={this.handleStop}


### PR DESCRIPTION
Fixes #121 

Without fix:


https://user-images.githubusercontent.com/10371003/201511202-d7d2ef2c-ffee-4585-83b5-474cbfdbc899.mov




With fix in this PR:


https://user-images.githubusercontent.com/10371003/201511080-5035a888-1814-4749-b6f7-a0ac5c13ea0b.mov





We have a local state in the Modal component which has the content to be shown in the tooltip. So when we switch to the next step we don't end up showing the next steps title immediately, instead we wait for the opacity to be set to 0 and then set the next steps content. Also we store `isFirstStep` and `isLastStep` in state as well as they too are shown in the tooltip.