### PR TITLE
add null check to prevent TypeError

### DIFF
--- a/src/components/TourGuideProvider.tsx
+++ b/src/components/TourGuideProvider.tsx
@@ -118,6 +118,7 @@ export const TourGuideProvider = ({
   const moveToCurrentStep = async (key: string) => {
     const size = await currentStep[key]?.target.measure()
     if (
+      size === undefined ||
       isNaN(size.width) ||
       isNaN(size.height) ||
       isNaN(size.x) ||


### PR DESCRIPTION
In some (rare) cases `size` was undefined.
Adding a small checks should prevent the `TypeError Cannot read property 'width' of undefined`

![Screenshot 2023-03-28 at 10 22 18](https://user-images.githubusercontent.com/18392496/228186840-a6fbbcab-26e4-4886-9a3c-0339f9e4421a.png)
