### PR TITLE
fix: dismissOnPress on svgMask wrapper (Android)

### DIFF
--- a/src/components/SvgMask.tsx
+++ b/src/components/SvgMask.tsx
@@ -5,11 +5,10 @@ import {
   Easing,
   LayoutChangeEvent,
   Platform,
-  StyleProp,
-  View,
-  ViewStyle,
-  TouchableWithoutFeedback,
+  Pressable,
   ScaledSize,
+  StyleProp,
+  ViewStyle,
 } from 'react-native'
 import Svg, { PathProps } from 'react-native-svg'
 import { IStep, ValueXY } from '../types'
@@ -186,13 +185,12 @@ export class SvgMask extends Component<Props, State> {
       return null
     }
     const { dismissOnPress, stop } = this.props
-    const Wrapper: any = dismissOnPress ? TouchableWithoutFeedback : View
 
     return (
-      <Wrapper
+      <Pressable
         style={this.props.style}
         onLayout={this.handleLayout}
-        pointerEvents='none'
+        pointerEvents={dismissOnPress ? undefined : 'none'}
         onPress={dismissOnPress ? stop : undefined}
       >
         <Svg
@@ -209,7 +207,7 @@ export class SvgMask extends Component<Props, State> {
             opacity={this.state.opacity as any}
           />
         </Svg>
-      </Wrapper>
+      </Pressable>
     )
   }
 }


### PR DESCRIPTION
hi there,

the `dismissOnPress` feature from `TourGuideProviderProps` wasn't working for me due to `TouchableWithoutFeedback` and the `pointer-event` set to `none` in the svgMask wrapper.
the issue only occured on Android (SDK 32, RN 0.70.6), on iOS it appears to be working as expected though.

i fixed it the following way ⬇️