### PR TITLE
fix(Modal): make sure currentStep in defined before accessing tooltipBottomOffset

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -191,9 +191,9 @@ export class Modal extends React.Component<ModalProps, State> {
       verticalPosition === 'bottom'
         ? tooltip.top
         : obj.top -
-        MARGIN -
-        135 -
-        (this.props.currentStep!.tooltipBottomOffset || 0)
+          MARGIN -
+          135 -
+          (this.props.currentStep?.tooltipBottomOffset || 0)
     const translateAnim = Animated.timing(this.state.tooltipTranslateY, {
       toValue,
       duration,
@@ -313,10 +313,12 @@ export class Modal extends React.Component<ModalProps, State> {
   }
 
   renderNonInteractionPlaceholder() {
-    return this.props.preventOutsideInteraction ? <View
-      style={[StyleSheet.absoluteFill, styles.nonInteractionPlaceholder]} /> : null
+    return this.props.preventOutsideInteraction ? (
+      <View
+        style={[StyleSheet.absoluteFill, styles.nonInteractionPlaceholder]}
+      />
+    ) : null
   }
-
 
   render() {
     const containerVisible = this.state.containerVisible || this.props.visible
@@ -334,8 +336,6 @@ export class Modal extends React.Component<ModalProps, State> {
           onLayout={this.handleLayoutChange}
           pointerEvents='box-none'
         >
-
-
           {contentVisible && (
             <>
               {this.renderMask()}


### PR DESCRIPTION
In some (rare) cases currentStep was undefined.
Adding a small checks should prevent the TypeError.

![image](https://github.com/xcarpentier/rn-tourguide/assets/63585162/19372b8d-be7b-49fc-9d50-02dc718ce44b)
